### PR TITLE
ddns-script: fix update_url incorrect for duckdns.org service

### DIFF
--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -82,7 +82,7 @@
 
 "dtdns.com"		"http://www.dtdns.com/api/autodns.cfm?id=[DOMAIN]&pw=[PASSWORD]&ip=[IP]"
 
-"duckdns.org"		"http://www.duckdns.org/update?domains=[USERNAME]&token=[PASSWORD]&ip=[IP]"	"OK"
+"duckdns.org"		"http://www.duckdns.org/update?domains=[DOMAIN]&token=[PASSWORD]&ip=[IP]"	"OK"
 
 "duiadns.net"		"http://ip.duiadns.net/dynamic.duia?host=[DOMAIN]&password=[PASSWORD]&ip4=[IP]"
 


### PR DESCRIPTION
Maintainer: wendy2001011
Compile tested: arch:arm, OpenWRT/LEDE version:Chaos Calmer 
Run tested: arch:arm, OpenWRT/LEDE version:Chaos Calmer, tests done

Description:
ddns-script: fix update_url incorrect for duckdns.org service
Signed-off-by: wendy2001011 <wendy2001011@163.com>

For duckdns.org service, 
update_url should be "http://www.duckdns.org/update?domains=[DOMAIN]&token=[PASSWORD]&ip=[IP]".
Using "domains=[DOMAIN]&token=[PASSWORD]", DDNS provider answered:"OK", update successful 
Using "domains=[USERNAME]&token=[PASSWORD]", DDNS provider answered:"KO", IP update not accepted by DDNS Provider

The following is the log,
081749       : Update needed - L: '124.206.234.219' <> R: '124.206.234.205'
081749       : #> /usr/bin/curl -RsS -o /var/run/ddns/myddns_ipv4.dat --stderr /var/run/ddns/myddns_ipv4.err --insecure --noproxy '*' 'https://www.duckdns.org/update?domains=wuwendy2018.duckdns.org&token=72074ff0-1866-4fd7-a0ca-883618e5d418&ip=124.206.234.219'
081752       : DDNS Provider answered:
OK
081752  info : Update successful - IP '124.206.234.219' send

075259       : Update needed - L: '124.206.234.205' <> R: '60.247.121.202'
075300       : #> /usr/bin/curl -RsS -o /var/run/ddns/myddns_ipv4.dat --stderr /var/run/ddns/myddns_ipv4.err --insecure --noproxy '*' 'https://www.duckdns.org/update?domains=bear.mif%40gmail.com&token=72074ff0-1866-4fd7-a0ca-883618e5d418&ip=124.206.234.205'
075307       : DDNS Provider answered:
KO
075307 ERROR : IP update not accepted by DDNS Provider

